### PR TITLE
Remove "ITK" from the module name.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,3 @@
-project(ITKIOMGH)
-set(ITKIOMGH_LIBRARIES ITKIOMGH)
+project(MGHIO)
+set(MGHIO_LIBRARIES MGHIO)
 itk_module_impl()

--- a/include/itkMGHImageIO.h
+++ b/include/itkMGHImageIO.h
@@ -33,7 +33,7 @@ namespace itk
  * package under grants XXXX
  *
  * \ingroup IOFilters
- * \ingroup ITKIOMGH
+ * \ingroup MGHIO
  */
 class MGHImageIO:public ImageIOBase
 {

--- a/include/itkMGHImageIOFactory.h
+++ b/include/itkMGHImageIOFactory.h
@@ -25,7 +25,7 @@ namespace itk
 {
 /** \class MGHImageIOFactory
    * \brief Create instances of MGHImageIO objects using an object factory.
-   * \ingroup ITKIOMGH
+   * \ingroup MGHIO
    */
 class MGHImageIOFactory : public ObjectFactoryBase
 {

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -1,7 +1,7 @@
 set(DOCUMENTATION "This modules contains an ImageIO class to read or write the
   MGH file format that is an integral part of FreeSurfer based tools.")
 
-itk_module(ITKIOMGH
+itk_module(MGHIO
   DEPENDS
     ITKIOImageBase
     ITKZLIB

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -8,6 +8,7 @@ itk_module(MGHIO
   TEST_DEPENDS
     ITKTestKernel
     ITKTransform
+  EXCLUDE_FROM_ALL
   DESCRIPTION
     "${DOCUMENTATION}"
 )

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -7,7 +7,6 @@ itk_module(MGHIO
     ITKZLIB
   TEST_DEPENDS
     ITKTestKernel
-    ITKTransform
   EXCLUDE_FROM_ALL
   DESCRIPTION
     "${DOCUMENTATION}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,5 +4,5 @@ itkMGHImageIO.cxx
 )
 
 add_library(MGHIO ${MGHIO_SRC})
-target_link_libraries(MGHIO ${ITKIOImageBase_LIBRARIES} ${ITKTransform_LIBRARIES})
+target_link_libraries(MGHIO ${ITKIOImageBase_LIBRARIES} ${ITKZLIB_LIBRARIES})
 itk_module_target(MGHIO)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
-set(ITKIOMGH_SRC
+set(MGHIO_SRC
 itkMGHImageIOFactory.cxx
 itkMGHImageIO.cxx
 )
 
-add_library(ITKIOMGH ${ITKIOMGH_SRC})
-target_link_libraries(ITKIOMGH  ${ITKMGH_LIBRARIES} ${ITKIOImageBase_LIBRARIES} ${ITKTransform_LIBRARIES})
-itk_module_target(ITKIOMGH)
+add_library(MGHIO ${MGHIO_SRC})
+target_link_libraries(MGHIO ${ITKIOImageBase_LIBRARIES} ${ITKTransform_LIBRARIES})
+itk_module_target(MGHIO)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,9 +5,6 @@ set(MGHIOTests
 
 set(MGH_DATA_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/MD5)
 
-# For itkMGHImageIOTest.h.
-include_directories( ${MGHIO_SOURCE_DIR}/test )
-
 CreateTestDriver(MGHIO  "${MGHIO-Test_LIBRARIES}" "${MGHIOTests}")
 
 itk_add_test(NAME MGHFactoryCreationTest

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,37 +1,37 @@
 itk_module_test()
-set(ITKIOMGHTests
+set(MGHIOTests
     itkMGHImageIOTest.cxx
 )
 
 set(MGH_DATA_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/MD5)
 
 # For itkMGHImageIOTest.h.
-include_directories( ${ITKIOMGH_SOURCE_DIR}/test )
+include_directories( ${MGHIO_SOURCE_DIR}/test )
 
-CreateTestDriver(ITKIOMGH  "${ITKIOMGH-Test_LIBRARIES}" "${ITKIOMGHTests}")
+CreateTestDriver(MGHIO  "${MGHIO-Test_LIBRARIES}" "${MGHIOTests}")
 
 itk_add_test(NAME MGHFactoryCreationTest
-      COMMAND ITKIOMGHTestDriver itkMGHImageIOTest
+      COMMAND MGHIOTestDriver itkMGHImageIOTest
               ${ITK_TEST_OUTPUT_DIR} FactoryCreationTest )
 
 itk_add_test(NAME MGHReadImagesTest_mgz
-      COMMAND ITKIOMGHTestDriver itkMGHImageIOTest
+      COMMAND MGHIOTestDriver itkMGHImageIOTest
               ${ITK_TEST_OUTPUT_DIR} ReadImagesTest
               DATA{${MGH_DATA_ROOT}/T1.mgz} TEST.mgz
               )
 
 itk_add_test(NAME MGHReadImagesTest_mgh
-      COMMAND ITKIOMGHTestDriver itkMGHImageIOTest
+      COMMAND MGHIOTestDriver itkMGHImageIOTest
               ${ITK_TEST_OUTPUT_DIR} ReadImagesTest
               DATA{${MGH_DATA_ROOT}/T1_uncompresed.mgh} TEST.mgh
               )
 
 itk_add_test(NAME MGHReadImagesTest_mgh.gz
-      COMMAND ITKIOMGHTestDriver itkMGHImageIOTest
+      COMMAND MGHIOTestDriver itkMGHImageIOTest
               ${ITK_TEST_OUTPUT_DIR} ReadImagesTest
               DATA{${MGH_DATA_ROOT}/T1_longname.mgh.gz} TEST.mgh.gz
               )
 
 itk_add_test(NAME itkMGHIOInternalTests
-      COMMAND ITKIOMGHTestDriver itkMGHImageIOTest
+      COMMAND MGHIOTestDriver itkMGHImageIOTest
               ${ITK_TEST_OUTPUT_DIR} TestReadWriteOfSmallImageOfAllTypes )

--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,3 +1,3 @@
-itk_wrap_module(ITKIOMGH)
+itk_wrap_module(MGHIO)
 itk_auto_load_submodules()
 itk_end_wrap_module()


### PR DESCRIPTION
Following the new naming rules for ITK remote modules, 
the remote module name should not contain the "ITK" prefix.
