### PR TITLE
BUG: missing steps converting origin back to freesurfer space

### DIFF
--- a/src/itkMGHImageIO.cxx
+++ b/src/itkMGHImageIO.cxx
@@ -650,18 +650,23 @@ MGHImageIO
     this->TWrite(*cit);
     }
 
-  // write c_r, c_a, c_s
-  // defined as origin + DC x resolution x ( dim0/2 , dim1/2, dim2/2 )
+  const float fcx = static_cast<float>(m_Dimensions[0]) / 2.0f;
+  const float fcy = static_cast<float>(m_Dimensions[1]) / 2.0f;
+  const float fcz = static_cast<float>(m_Dimensions[2]) / 2.0f;
+  float c[3];
   for( unsigned int ui = 0; ui < 3; ++ui )
     {
-    float crasBuf = m_Origin[ui];
-    for( unsigned int uj = 0; uj < 3; ++uj )
-      {
-      crasBuf += vvRas[ui][uj] * m_Spacing[uj] * (float)m_Dimensions[uj] / 2.0f;
-      }
-    this->TWrite(crasBuf );
-    }   // next ui
-
+    c[ui] = m_Origin[ui]
+      + ( vvRas[ui][0] * m_Spacing[0] * fcx
+          + vvRas[ui][1] * m_Spacing[1] * fcy
+          + vvRas[ui][2] * m_Spacing[2] * fcz );
+    }
+  c[0] *= -1.0;
+  c[1] *= -1.0;
+  for( unsigned int ui = 0; ui < 3; ++ui )
+    {
+    this->TWrite(c[ui]);
+    }
   // fill the rest of the buffer with zeros
   const char zerobyte(0);
   for(unsigned int i = 0; i < FS_UNUSED_HEADER_SIZE; ++i)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,3 +32,9 @@ itk_add_test(NAME MGHReadImagesTest_mgh.gz
 itk_add_test(NAME itkMGHIOInternalTests
       COMMAND MGHIOTestDriver itkMGHImageIOTest
               ${ITK_TEST_OUTPUT_DIR} TestReadWriteOfSmallImageOfAllTypes )
+itk_add_test(NAME itkMGHIOOriginTest
+  COMMAND MGHIOTestDriver itkMGHImageIOTest
+  ${ITK_TEST_OUTPUT_DIR} TestOriginWriteTest
+  DATA{${MGH_DATA_ROOT}/T1_longname.mgh.gz} OriginTEST.mgh.gz
+  )
+

--- a/test/itkMGHImageIOTest.cxx
+++ b/test/itkMGHImageIOTest.cxx
@@ -110,6 +110,48 @@ int itkMGHImageIOTest(int ac, char* av[])
       returnStatus = EXIT_FAILURE;
       }
     }
+  else if( TestMode == "TestOriginWriteTest" )
+    {
+    typedef itk::Image<int, 3> ImageType;
+    ImageType::Pointer input;
+    const std::string imageToBeRead(av[3]);
+    const std::string imageToBeWritten(av[4]);
+    try
+      {
+      std::cout << "Reading Image: " << imageToBeRead << std::endl;
+      input = itk::IOTestHelper::ReadImage<ImageType>(imageToBeRead);
+      std::cout << input << std::endl;
+
+      ImageType::PointType origin;
+      origin[0] = -123.4;
+      origin[1] = 456.7;
+      origin[2] = -890.0;
+      input->SetOrigin(origin);
+
+      itk::ImageFileWriter<ImageType>::Pointer testFactoryWriter=itk::ImageFileWriter<ImageType>::New();
+
+      testFactoryWriter->SetFileName(imageToBeWritten);
+      testFactoryWriter->SetInput(input);
+      testFactoryWriter->Update();
+      itk::ImageFileReader<ImageType>::Pointer testFactoryReader=itk::ImageFileReader<ImageType>::New();
+      testFactoryReader->SetFileName(imageToBeWritten);
+      testFactoryReader->Update();
+      ImageType::Pointer new_image = testFactoryReader->GetOutput();
+      ImageType::PointType origin2 = new_image->GetOrigin();
+      if(origin != origin2)
+        {
+        std::cerr << "Origin written and origin read do not match: "
+                  << "written: " << origin
+                  << " read: " << origin2 << std::endl;
+        returnStatus = EXIT_FAILURE;
+        }
+      }
+    catch (itk::ExceptionObject &e)
+      {
+      e.Print(std::cerr);
+      returnStatus = EXIT_FAILURE;
+      }
+    }
   else
     {
     std::cerr << "Invalid TestMode : " << TestMode << std::endl;


### PR DESCRIPTION
This was a bug identified by Eun Young Kim eunyoung-kim@uiowa.edu

If you read in an MGZ file, and then subsequently wrote out an MGZ file, the origin gets changed.

In fact I'd say if you read in an image in any ITK-supported format, and wrote it out as an MGZ file, then the origin will be wrong.

The problem was (I believe) in forgetting to reverse the sign of the X & Y components of the origin before writing.  I changed the code in WriteHeader so that it would match the code in ReadHeader.
