### PR TITLE
BUG: Fix KWStyle error for header guarder

### DIFF
--- a/include/itkMGHImageIO.h
+++ b/include/itkMGHImageIO.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __itkMGHImageIO_h
-#define __itkMGHImageIO_h
+#ifndef itkMGHImageIO_h
+#define itkMGHImageIO_h
 
 #include "itkMatrix.h"
 #include "itkImageIOBase.h"
@@ -130,4 +130,4 @@ private:
 };
 } // end namespace itk
 
-#endif // __itkMGHImageIO_h
+#endif // itkMGHImageIO_h

--- a/include/itkMGHImageIOFactory.h
+++ b/include/itkMGHImageIOFactory.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __itkMGHImageIOFactory_h
-#define __itkMGHImageIOFactory_h
+#ifndef itkMGHImageIOFactory_h
+#define itkMGHImageIOFactory_h
 
 #include "itkObjectFactoryBase.h"
 #include "itkImageIOBase.h"
@@ -66,4 +66,4 @@ private:
 };
 } // end namespace itk
 
-#endif /// __itkMGHImageIOFactory_h
+#endif /// itkMGHImageIOFactory_h


### PR DESCRIPTION
Remove usage of reserved "__" prefix.

Addresses test failures on the dashboard:
https://open.cdash.org/testDetails.php?test=318703403&build=3751081
