### PR TITLE
BUG: Fix KWStyle error for header guarderd in test

### DIFF
--- a/test/itkMGHImageIOTest.h
+++ b/test/itkMGHImageIOTest.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __itkMGHImageIOTest_h
-#define __itkMGHImageIOTest_h
+#ifndef itkMGHImageIOTest_h
+#define itkMGHImageIOTest_h
 
 #include <fstream>
 #include <vector>


### PR DESCRIPTION
Remove usage of reserved "__" prefix. The test
header needed to have the __prefix removed.
