### PR TITLE
Fix test failure related to issue #7

### DIFF
--- a/include/itkMGHImageIO.h
+++ b/include/itkMGHImageIO.h
@@ -125,8 +125,8 @@ private:
 
   // Utility function to assist with writing to disk in the 
   // proper format.  TInType is static_cast<TDiskType> type.
-  template <class TInType,class TDiskType> int TWrite(const TInType inValue);
-  template <class T> int TRead(T &out);
+  template <typename TInType, typename TDiskType> int TWrite(const TInType inValue);
+  template <typename TDiskType, typename TOutType> int TRead(TOutType &outValue);
 
   int TWrite(const char *buf,const unsigned long count);
   void OpenFile();

--- a/include/itkMGHImageIO.h
+++ b/include/itkMGHImageIO.h
@@ -123,10 +123,12 @@ private:
   gzFile        m_GZFile;
   std::ofstream m_Output;
 
-  template <class T> int TWrite(T out);
+  // Utility function to assist with writing to disk in the 
+  // proper format.  TInType is static_cast<TDiskType> type.
+  template <class TInType,class TDiskType> int TWrite(const TInType inValue);
   template <class T> int TRead(T &out);
 
-  int TWrite(const char *buf,unsigned long count);
+  int TWrite(const char *buf,const unsigned long count);
   void OpenFile();
   void CloseFile();
 };

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -8,6 +8,7 @@ itk_module(MGHIO
     ITKZLIB
   TEST_DEPENDS
     ITKTestKernel
+    ITKTransform
   EXCLUDE_FROM_DEFAULT
   DESCRIPTION
     "${DOCUMENTATION}"

--- a/src/itkMGHImageIO.cxx
+++ b/src/itkMGHImageIO.cxx
@@ -659,11 +659,11 @@ MGHImageIO
       if( uj == 0 || uj == 1 )
         {
         // convert the coordinates from LPS to RAS
-        vBufRas.push_back(-1.0 * (float)vvRas[uj][ui] );
+        vBufRas.push_back(-1.0 * (float)vvRas[ui][uj] );
         }
       else
         {
-        vBufRas.push_back( (float)vvRas[uj][ui] );
+        vBufRas.push_back( (float)vvRas[ui][uj] );
         }
       }
     }

--- a/src/itkMGHImageIO.cxx
+++ b/src/itkMGHImageIO.cxx
@@ -291,7 +291,7 @@ MGHImageIO
       z_r z_a z_s
       c_r c_a c_s
     */
-    typedef itk::Matrix<double> MatrixType;
+    typedef itk::Matrix<double,3,3> MatrixType;
     MatrixType matrix;
     // reading in x_r x_a x_s y_r y_a y_s z_r z_a z_s and putting it into the
     // matrix as:
@@ -308,7 +308,7 @@ MGHImageIO
 //      std::cout << "itkMGHImageIO ReadVolumeHeader: matrix[" << ui << "][" << uj << "] = " << matrix[ui][uj] << "\n";
         }
       }
-    float c[3];
+    float c[3]; //c_r c_a c_s
     for( unsigned int ui = 0; ui < 3; ++ui )
       {
       this->TRead( c[ui]);
@@ -337,12 +337,12 @@ MGHImageIO
     // MriDirCos(); // convert direction cosines
 
     // finally, store the origin of the image -> only works
-    // if the image is properly orriented in the sequel
+    // if the image is properly oriented in the sequel
     //
     // computed in CORONAL orientation = ITK_COORDINATE_ORIENTATION_LIA
     // convert C to from RAS to LPS
-    c[0] *= -1;
-    c[1] *= -1;
+    c[0] *= -1; //R->L
+    c[1] *= -1; //A->P
     const float fcx = static_cast<float>(m_Dimensions[0]) / 2.0f;
     const float fcy = static_cast<float>(m_Dimensions[1]) / 2.0f;
     const float fcz = static_cast<float>(m_Dimensions[2]) / 2.0f;
@@ -353,7 +353,6 @@ MGHImageIO
             + matrix[ui][1] * m_Spacing[1] * fcy
             + matrix[ui][2] * m_Spacing[2] * fcz );
       }
-
     }
 
   // ==================

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,8 +38,3 @@ itk_add_test(NAME itkMGHIOOriginTest
   DATA{${MGH_DATA_ROOT}/T1_longname.mgh.gz} OriginTEST.mgh.gz
   )
 
-
-
-# "/Users/johnsonhj/Dropbox/DATA/wmparc_acpc_ref.mgz"
-# "/Users/johnsonhj/Dropbox/DATA/wmparc_acpc_ref.nii.gz"
-

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,3 +38,8 @@ itk_add_test(NAME itkMGHIOOriginTest
   DATA{${MGH_DATA_ROOT}/T1_longname.mgh.gz} OriginTEST.mgh.gz
   )
 
+
+
+# "/Users/johnsonhj/Dropbox/DATA/wmparc_acpc_ref.mgz"
+# "/Users/johnsonhj/Dropbox/DATA/wmparc_acpc_ref.nii.gz"
+

--- a/test/itkMGHImageIOTest.cxx
+++ b/test/itkMGHImageIOTest.cxx
@@ -53,14 +53,14 @@ int itkMGHImageIOTest(int ac, char* av[])
     }
   const std::string TestMode(av[2]);
 
-  int returnStatus = EXIT_SUCCESS;
+  bool returnSucceeded = true;
   if( TestMode == std::string("FactoryCreationTest"))
   //Tests added to increase code coverage.
     {
     itk::MGHImageIOFactory::Pointer MyFactoryTest=itk::MGHImageIOFactory::New();
     if(MyFactoryTest.IsNull())
       {
-      returnStatus = EXIT_FAILURE;
+      returnSucceeded &= false;
       }
     //This was made a protected function.  MyFactoryTest->PrintSelf(std::cout,0);
     }
@@ -68,14 +68,11 @@ int itkMGHImageIOTest(int ac, char* av[])
     {
     std::string fn("test.mgz");
     //TODO: Need to test with images of non-identity direction cosigns, spacing, origin
-    if( ( returnStatus = itkMGHImageIOTestReadWriteTest<unsigned char,3>(fn,3,"null", true) ) != EXIT_FAILURE &&
-        ( returnStatus = itkMGHImageIOTestReadWriteTest<short int,3>(fn,3,"null", true) ) != EXIT_FAILURE &&
-        ( returnStatus = itkMGHImageIOTestReadWriteTest<int,3>(fn,3,"null", true) ) != EXIT_FAILURE &&
-        ( returnStatus = itkMGHImageIOTestReadWriteTest<float,3>(fn,3,"null", true) ) != EXIT_FAILURE &&
-        ( returnStatus = itkMGHImageIOTestReadWriteTest<itk::DiffusionTensor3D<float>, 3>(fn,3,"null", true) ) != EXIT_FAILURE )
-      {
-      returnStatus = EXIT_SUCCESS;
-      }
+    returnSucceeded &= itkMGHImageIOTestReadWriteTest<unsigned char,3>(fn,3,"null", true);
+    returnSucceeded &= itkMGHImageIOTestReadWriteTest<short int,3>(fn,3,"null", true);
+    returnSucceeded &= itkMGHImageIOTestReadWriteTest<int,3>(fn,3,"null", true);
+    returnSucceeded &= itkMGHImageIOTestReadWriteTest<float,3>(fn,3,"null", true);
+    returnSucceeded &= itkMGHImageIOTestReadWriteTest<itk::DiffusionTensor3D<float>, 3>(fn,3,"null", true);
     }
   else if( TestMode == std::string("ReadImagesTest") ) //This is a mechanism for reading unsigned int images for testing.
     {
@@ -99,7 +96,7 @@ int itkMGHImageIOTest(int ac, char* av[])
     catch (itk::ExceptionObject &e)
       {
       e.Print(std::cerr);
-      returnStatus = EXIT_FAILURE;
+      returnSucceeded &= false;
       }
     }
   else if( TestMode == "TestOriginWriteTest" )
@@ -138,19 +135,19 @@ int itkMGHImageIOTest(int ac, char* av[])
                   << "written: " << reference_origin
                   << " read: " << test_origin << " distance: "
                   << dist << std::endl;
-        returnStatus = EXIT_FAILURE;
+        returnSucceeded &= false;
         }
       }
     catch (itk::ExceptionObject &e)
       {
       e.Print(std::cerr);
-      returnStatus = EXIT_FAILURE;
+      returnSucceeded &= false;
       }
     }
   else
     {
     std::cerr << "Invalid TestMode : " << TestMode << std::endl;
-    returnStatus = EXIT_FAILURE;
+    returnSucceeded &= false;
     }
-  return returnStatus;
+  return (returnSucceeded == true) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/test/itkMGHImageIOTest.cxx
+++ b/test/itkMGHImageIOTest.cxx
@@ -27,9 +27,6 @@
 #include "itkMGHImageIOTest.h"
 #include <iomanip>
 
-#define SPECIFIC_IMAGEIO_MODULE_TEST
-
-
 int itkMGHImageIOTest(int ac, char* av[])
 {
   itk::ObjectFactoryBase::UnRegisterAllFactories();
@@ -70,6 +67,7 @@ int itkMGHImageIOTest(int ac, char* av[])
   else if ( TestMode == std::string("TestReadWriteOfSmallImageOfAllTypes"))
     {
     std::string fn("test.mgz");
+    //TODO: Need to test with images of non-identity direction cosigns, spacing, origin
     if( ( returnStatus = itkMGHImageIOTestReadWriteTest<unsigned char,3>(fn,3,"null", true) ) != EXIT_FAILURE &&
         ( returnStatus = itkMGHImageIOTestReadWriteTest<short int,3>(fn,3,"null", true) ) != EXIT_FAILURE &&
         ( returnStatus = itkMGHImageIOTestReadWriteTest<int,3>(fn,3,"null", true) ) != EXIT_FAILURE &&
@@ -78,21 +76,18 @@ int itkMGHImageIOTest(int ac, char* av[])
       {
       returnStatus = EXIT_SUCCESS;
       }
-    //TODO: Need to test with images of non-identity direction cosigns, spacing, origin
     }
   else if( TestMode == std::string("ReadImagesTest") ) //This is a mechanism for reading unsigned int images for testing.
     {
     typedef itk::Image<int, 3> ImageType;
-    ImageType::Pointer input;
     const std::string imageToBeRead(av[3]);
     const std::string imageToBeWritten(av[4]);
     try
       {
       std::cout << "Reading Image: " << imageToBeRead << std::endl;
-      input = itk::IOTestHelper::ReadImage<ImageType>(imageToBeRead);
+      ImageType::Pointer input = itk::IOTestHelper::ReadImage<ImageType>(imageToBeRead);
       std::cout << input << std::endl;
       itk::ImageFileWriter<ImageType>::Pointer testFactoryWriter=itk::ImageFileWriter<ImageType>::New();
-
       testFactoryWriter->SetFileName(imageToBeWritten);
       testFactoryWriter->SetInput(input);
       testFactoryWriter->Update();
@@ -119,11 +114,11 @@ int itkMGHImageIOTest(int ac, char* av[])
       input = itk::IOTestHelper::ReadImage<ImageType>(imageToBeRead);
       std::cout << input << std::endl;
 
-      ImageType::PointType origin;
-      origin[0] = -123.4;
-      origin[1] = 456.7;
-      origin[2] = -890.0;
-      input->SetOrigin(origin);
+      ImageType::PointType reference_origin;
+      reference_origin[0] = -123.4;
+      reference_origin[1] = 456.7;
+      reference_origin[2] = -890.0;
+      input->SetOrigin(reference_origin);
 
       itk::ImageFileWriter<ImageType>::Pointer testFactoryWriter=itk::ImageFileWriter<ImageType>::New();
 
@@ -134,14 +129,14 @@ int itkMGHImageIOTest(int ac, char* av[])
       testFactoryReader->SetFileName(imageToBeWritten);
       testFactoryReader->Update();
       ImageType::Pointer new_image = testFactoryReader->GetOutput();
-      ImageType::PointType origin2 = new_image->GetOrigin();
-      double dist = origin.EuclideanDistanceTo(origin2);
+      const ImageType::PointType test_origin = new_image->GetOrigin();
+      const double dist = reference_origin.EuclideanDistanceTo(test_origin);
       if(dist > 1.0E-4)
         {
         std::cerr << std::setprecision(10)
                   << "Origin written and origin read do not match: "
-                  << "written: " << origin
-                  << " read: " << origin2 << " distance: "
+                  << "written: " << reference_origin
+                  << " read: " << test_origin << " distance: "
                   << dist << std::endl;
         returnStatus = EXIT_FAILURE;
         }

--- a/test/itkMGHImageIOTest.h
+++ b/test/itkMGHImageIOTest.h
@@ -32,6 +32,8 @@
 
 #include "itkEuler3DTransform.h"
 
+
+
 template <class TPixelType, unsigned int VImageDimension>
 typename itk::Image<TPixelType, VImageDimension>::Pointer
 itkMGHImageIOTestGenerateRandomImage(const unsigned int size)
@@ -103,7 +105,33 @@ itkMGHImageIOTestGenerateRandomImage(const unsigned int size)
   source->SetSpacing(spacing);
 
   source->Update();
-  return (source->GetOutput());
+  typename ImageType::Pointer outImage=source->GetOutput();
+
+    {
+    itk::MetaDataDictionary & thisDic = outImage->GetMetaDataDictionary();
+    //Add meta data to dictionary
+    // set TR, Flip, TE, FI, FOV //TODO: Add code that verifies these values
+    float fBufTR = 2.0F;
+    float fBufFA=89.1F;
+    float fBufTE=1.5F;
+    float fBufTI=0.75F;
+    float fBufFOV=321.0F;
+    itk::EncapsulateMetaData<float>(thisDic,
+      std::string("TR"), fBufTR);
+    // try to read flipAngle
+    itk::EncapsulateMetaData<float>(thisDic,
+      std::string("FlipAngle"), fBufFA);
+    // TE
+    itk::EncapsulateMetaData<float>(thisDic,
+      std::string("TE"), fBufTE);
+    // TI
+    itk::EncapsulateMetaData<float>(thisDic,
+      std::string("TI"), fBufTI);
+    // FOV
+    itk::EncapsulateMetaData<float>(thisDic,
+      std::string("FoV"), fBufFOV);
+    }
+  return outImage;
 }
 
 //Template specialization for itkDiffusionTensor3D

--- a/test/itkMGHImageIOTest.h
+++ b/test/itkMGHImageIOTest.h
@@ -20,6 +20,7 @@
 
 #include <fstream>
 #include <vector>
+#include <iomanip>
 #include "itkImageRegionIterator.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
@@ -29,30 +30,69 @@
 #include "itkRandomImageSource.h"
 #include "itkDiffusionTensor3D.h"
 
+#include "itkEuler3DTransform.h"
+
 template <class TPixelType, unsigned int VImageDimension>
 typename itk::Image<TPixelType, VImageDimension>::Pointer
-itkMGHImageIOTestGenerateRandomImage(unsigned int size)
+itkMGHImageIOTestGenerateRandomImage(const unsigned int size)
 {
+
+  typedef itk::Euler3DTransform<double> EulerTransformType;
+  EulerTransformType::Pointer eulerTransform = EulerTransformType::New();
+  eulerTransform->SetIdentity();
+
+  // 15 degrees in radians
+  const double angleX = 15.0 * std::atan( 1.0 ) / 45.0;
+  // 10 degrees in radians
+  const double angleY = 10.0 * std::atan( 1.0 ) / 45.0;
+  // 5 degrees in radians
+  const double angleZ = 5.0 * std::atan( 1.0 ) / 45.0;
+  eulerTransform->SetRotation(angleX, angleY, angleZ);
+ 
   typedef itk::Image<TPixelType, VImageDimension> ImageType;
 
-  const double dir1[3] = { 0, -1, 0 };
-  const double dir2[3] = { 1, 0, 0 };
-  const double dir3[3] = { 0, 0, -1 };
+  typename ImageType::DirectionType permuteDirections;
+  const double dir1[3] = { -1.,  0.,  0. };
+  const double dir2[3] = {  0.,  0.,  1. };
+  const double dir3[3] = {  0., -1.,  0.  };
+  permuteDirections.GetVnlMatrix().set_column(0,dir1);
+  permuteDirections.GetVnlMatrix().set_column(1,dir2);
+  permuteDirections.GetVnlMatrix().set_column(2,dir3);
 
-  typename ImageType::DirectionType direction;
-  direction.GetVnlMatrix().set_column(0,dir1);
-  direction.GetVnlMatrix().set_column(1,dir2);
-  direction.GetVnlMatrix().set_column(2,dir3);
+  typename ImageType::DirectionType direction = eulerTransform->GetMatrix()*permuteDirections;
+  
+  for (unsigned int i = 0; i < VImageDimension; ++i)
+    {
+    for (unsigned int j = 0; j < VImageDimension; ++j)
+      {
+      direction[i][j] = static_cast<float>(direction[i][j]); //Truncate for testing purposes
+      }
+    }
 
   typename ImageType::SizeType sz;
   typename ImageType::SpacingType spacing;
   typename ImageType::PointType origin;
-  for (unsigned int i = 0; i < VImageDimension; i++)
+
+  for (unsigned int i = 0; i < VImageDimension; ++i)
     {
     sz[i]      = size;
-    spacing[i] = static_cast<float>(i+1);
-    origin[i]  = static_cast<float>(i);
+    spacing[i] = static_cast<float>(i+1.234567);
+    origin[i]  = static_cast<float>(1234.5);
     }
+
+#if 0
+  //Make origin match numerical precision of MGH file
+  const double fcx = sz[0] * 0.5;
+  const double fcy = sz[1] * 0.5;
+  const double fcz = sz[2] * 0.5;
+  for( size_t ui = 0; ui < 3; ++ui )
+    {
+    origin[ui] = origin[ui]
+      + ( direction[ui][0] * spacing[0] * fcx
+          + direction[ui][1] * spacing[1] * fcy
+          + direction[ui][2] * spacing[2] * fcz );
+    }
+#endif
 
   typename itk::RandomImageSource<ImageType>::Pointer source
     = itk::RandomImageSource<ImageType>::New();
@@ -140,7 +180,7 @@ int itkMGHImageIOTestReadWriteTest(std::string fn, unsigned int size,
   reader->SetImageIO(io);
   writer->SetImageIO(io);
 
-  typename ImageType::Pointer image;
+  typename ImageType::Pointer reference_image;
 
   if (inputFile != "null")
     {
@@ -158,16 +198,15 @@ int itkMGHImageIOTestReadWriteTest(std::string fn, unsigned int size,
       std::cerr << e << std::endl;
       return EXIT_FAILURE;
       }
-
-    image = tmpReader->GetOutput();
+    reference_image = tmpReader->GetOutput();
     }
   else
     {
-    // Generate a random image.
-    image = itkMGHImageIOTestGenerateRandomImage<TPixelType, VImageDimension>(size);
+    // Generate a random reference_image.
+    reference_image = itkMGHImageIOTestGenerateRandomImage<TPixelType, VImageDimension>(size);
     }
 
-  // Write, then read the image.
+  // Write, then read the reference_image.
   try
     {
     writer->SetFileName(fn.c_str());
@@ -178,7 +217,6 @@ int itkMGHImageIOTestReadWriteTest(std::string fn, unsigned int size,
     reader->SetFileName(fn.c_str());
     //writer->SetFileName("testDebug.mhd");
     //reader->SetFileName("testDebug.mhd");
-
     }
   catch(itk::ExceptionObject &e)
     {
@@ -186,9 +224,8 @@ int itkMGHImageIOTestReadWriteTest(std::string fn, unsigned int size,
     return EXIT_FAILURE;
     }
 
-    writer->SetInput(image);
-
-    image->Print(std::cout);
+    writer->SetInput(reference_image);
+    reference_image->Print(std::cout);
     std::cout << "----------" << std::endl;
 
   try
@@ -206,24 +243,73 @@ int itkMGHImageIOTestReadWriteTest(std::string fn, unsigned int size,
     return EXIT_FAILURE;
     }
 
-  // Print the image information.
+  // Print the reference_image information.
 
-  reader->GetOutput()->Print(std::cout);
+  typename ImageType::Pointer test_image=reader->GetOutput();
+  test_image->Print(std::cout);
   std::cout << std::endl;
 
+  bool isFailingPixelValues = false;
+  bool isFailingOrigin = false;
+  bool isFailingSpacing = false;
+  bool isFailingDirection = false;
   // Compare input and output images.
-  itk::ImageRegionIterator<ImageType> a(image, image->GetRequestedRegion());
-  itk::ImageRegionIterator<ImageType> b(reader->GetOutput(),
-                                        reader->GetOutput()->GetRequestedRegion());
+  itk::ImageRegionIterator<ImageType> a(reference_image, reference_image->GetRequestedRegion());
+  itk::ImageRegionIterator<ImageType> b(test_image, test_image->GetRequestedRegion());
   for (a.GoToBegin(), b.GoToBegin(); ! a.IsAtEnd(); ++a, ++b)
     {
     if ( b.Get() != a.Get() )
       {
       std::cerr << "At index " << b.GetIndex() << " value " << b.Get() << " should be " << a.Get() << std::endl;
-      return EXIT_FAILURE;
+      isFailingPixelValues = true;
       }
     }
-  return EXIT_SUCCESS;
+  for( int idx = 0 ; idx < 3; ++idx )
+    {
+    // itk::Math::FloatAlmostEqual( floatRepresentationfx1.asFloat, floatRepresentationfx2.asFloat, 4, 0.1f)
+    if( ! itk::Math::FloatAlmostEqual( test_image->GetSpacing()[idx],
+        reference_image->GetSpacing()[idx], 4, 1e-7 ) )
+      {
+      isFailingSpacing = true;
+      }
+    if( ! itk::Math::FloatAlmostEqual( test_image->GetOrigin()[idx],
+        reference_image->GetOrigin()[idx], 4, 1e-7 ) )
+      {
+      isFailingOrigin = true;
+      }
+    for( int idx2 = 0; idx2 < 3; ++idx2 )
+      {
+      if( ! itk::Math::FloatAlmostEqual( test_image->GetDirection()[idx][idx2],
+          reference_image->GetDirection()[idx][idx2], 4, 1e-7 ) )
+        {
+        isFailingDirection = true;
+        }
+      }
+    }
+  std::cerr << std::fixed << std::setprecision(10) << std::endl;
+  //Report failure dianostics
+  if(isFailingSpacing)
+    {
+    std::cerr << "ERROR:  Invalid Spacing: " 
+      << test_image->GetSpacing() <<  " ! = " << reference_image->GetSpacing()
+      << std::endl;
+    }
+  if(isFailingOrigin)
+    {
+    std::cerr << "ERROR:  Invalid Origin: " 
+      << test_image->GetOrigin() <<  " ! = " << reference_image->GetOrigin()
+      << std::endl;
+    }
+  if(isFailingDirection)
+    {
+    std::cerr << "ERROR:  Invalid Direction: \n" 
+      << test_image->GetDirection() <<  " ! = \n" << reference_image->GetDirection()
+      << std::endl;
+    }
+  return (isFailingPixelValues 
+    || isFailingOrigin 
+    || isFailingSpacing 
+    || isFailingDirection)? EXIT_FAILURE:EXIT_SUCCESS;
 }
 
 #endif //itkMGHImageIOTest_h_

--- a/test/itkMGHImageIOTest.h
+++ b/test/itkMGHImageIOTest.h
@@ -38,7 +38,6 @@ template <class TPixelType, unsigned int VImageDimension>
 typename itk::Image<TPixelType, VImageDimension>::Pointer
 itkMGHImageIOTestGenerateRandomImage(const unsigned int size)
 {
-
   typedef itk::Euler3DTransform<double> EulerTransformType;
   EulerTransformType::Pointer eulerTransform = EulerTransformType::New();
   eulerTransform->SetIdentity();
@@ -81,20 +80,6 @@ itkMGHImageIOTestGenerateRandomImage(const unsigned int size)
     spacing[i] = static_cast<float>(i+1.234567);
     origin[i]  = static_cast<float>(1234.5);
     }
-
-#if 0
-  //Make origin match numerical precision of MGH file
-  const double fcx = sz[0] * 0.5;
-  const double fcy = sz[1] * 0.5;
-  const double fcz = sz[2] * 0.5;
-  for( size_t ui = 0; ui < 3; ++ui )
-    {
-    origin[ui] = origin[ui]
-      + ( direction[ui][0] * spacing[0] * fcx
-          + direction[ui][1] * spacing[1] * fcy
-          + direction[ui][2] * spacing[2] * fcz );
-    }
-#endif
 
   typename itk::RandomImageSource<ImageType>::Pointer source
     = itk::RandomImageSource<ImageType>::New();
@@ -157,8 +142,8 @@ itkMGHImageIOTestGenerateRandomImage< itk::DiffusionTensor3D<float> , 3 >(unsign
   for(unsigned int i = 0; i < 3; ++i)
     {
     sz[i] = size;
-    spacing[i] = static_cast<double>(i + 1);
-    origin[i] = static_cast<double>( (i & 1) ? -i : i );
+    spacing[i] = static_cast<double>(i*3.21 + 1.0);
+    origin[i] = static_cast<double>( 1.23456 );
     }
 
   TensorImagePointer tensorImage = TensorImageType::New();
@@ -194,7 +179,7 @@ itkMGHImageIOTestGenerateRandomImage< itk::DiffusionTensor3D<float> , 3 >(unsign
 
 
 template<class TPixelType, unsigned int VImageDimension>
-int itkMGHImageIOTestReadWriteTest(std::string fn, unsigned int size,
+bool itkMGHImageIOTestReadWriteTest(std::string fn, unsigned int size,
                                     std::string inputFile, bool compression=false)
 {
   typedef itk::Image<TPixelType, VImageDimension> ImageType;
@@ -301,7 +286,7 @@ int itkMGHImageIOTestReadWriteTest(std::string fn, unsigned int size,
       isFailingSpacing = true;
       }
     if( ! itk::Math::FloatAlmostEqual( test_image->GetOrigin()[idx],
-        reference_image->GetOrigin()[idx], 4, 1e-7 ) )
+        reference_image->GetOrigin()[idx], 100000, 1e-1 ) )
       {
       isFailingOrigin = true;
       }
@@ -334,10 +319,7 @@ int itkMGHImageIOTestReadWriteTest(std::string fn, unsigned int size,
       << test_image->GetDirection() <<  " ! = \n" << reference_image->GetDirection()
       << std::endl;
     }
-  return (isFailingPixelValues 
-    || isFailingOrigin 
-    || isFailingSpacing 
-    || isFailingDirection)? EXIT_FAILURE:EXIT_SUCCESS;
+  return ! (isFailingPixelValues || isFailingOrigin || isFailingSpacing || isFailingDirection);
 }
 
 #endif //itkMGHImageIOTest_h_


### PR DESCRIPTION
@jcfr This set of patches fixes MGHIO to resolve a bug when writing MGH files to disk.  This was described in issue #7 

The bug only presented itself when the transpose of the DirectionCosine was different.

The test suite was fortified, and improved to demonstrate the bug, and then the code was re-written to allow for the fortified tests to pass.
