### PR TITLE
STYLE: Use Macro for Function Deletion

### DIFF
--- a/include/itkMGHImageIOFactory.h
+++ b/include/itkMGHImageIOFactory.h
@@ -63,8 +63,7 @@ protected:
   virtual void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
 private:
-  MGHImageIOFactory(const Self &);  //purposely not implemented
-  void operator=(const Self &);     //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(MGHImageIOFactory);
 };
 } // end namespace itk
 


### PR DESCRIPTION
Use ITK_DISALLOW_COPY_AND_ASSIGN macro to delete copy and assignment constructors which uses C++11's rigorous function deletion on compilers that support it.
