### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_AND_MOVE

### DIFF
--- a/include/itkMGHImageIOFactory.h
+++ b/include/itkMGHImageIOFactory.h
@@ -33,7 +33,7 @@ namespace itk
 class MGHIO_EXPORT MGHImageIOFactory : public ObjectFactoryBase
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MGHImageIOFactory);
+  ITK_DISALLOW_COPY_AND_MOVE(MGHImageIOFactory);
 
   /** Standard class type alias */
   using Self = MGHImageIOFactory;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.