### PR TITLE
remove recursive header includes

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
             cmake-build-type: "MinSizeRel"
 
     steps:

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "v5.1.1"
+            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "v5.1.1"
+            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "v5.1.1"
+            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -38,6 +38,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install ninja
+
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
 
     - name: Download ITK
       run: |
@@ -133,7 +136,7 @@ jobs:
       matrix:
         python-version: [36, 37, 38, 39]
         include:
-          - itk-python-git-tag: "v5.1.1.post1"
+          - itk-python-git-tag: "v5.2rc01"
 
     steps:
     - uses: actions/checkout@v2
@@ -169,10 +172,17 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.1.1.post1"
+          - itk-python-git-tag: "v5.2rc01"
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: 'Specific XCode version'
+      run: |
+        sudo xcode-select -s "/Applications/Xcode_11.7.app"
+
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
 
     - name: 'Fetch build script'
       run: |
@@ -198,9 +208,12 @@ jobs:
       matrix:
         python-version-minor: [6, 7, 8, 9]
         include:
-          - itk-python-git-tag: "v5.1.1.post1"
+          - itk-python-git-tag: "v5.2rc01"
 
     steps:
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
+
     - uses: actions/checkout@v2
       with:
         path: "im"
@@ -215,7 +228,7 @@ jobs:
       shell: bash
       run: |
         mv im ../../
-        cd ../../
+        cd ../../im
         curl -L "https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/${{ matrix.itk-python-git-tag }}/ITKPythonBuilds-windows.zip" -o "ITKPythonBuilds-windows.zip"
         7z x ITKPythonBuilds-windows.zip -o/c/P -aoa -r
         curl -L "https://data.kitware.com/api/v1/file/5c0ad59d8d777f2179dd3e9c/download" -o "doxygen-1.8.11.windows.bin.zip"
@@ -236,7 +249,7 @@ jobs:
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v1
       with:
-        name: WindowWheel3.${{ matrix.python-version-minor }}
+        name: WindowsWheel3.${{ matrix.python-version-minor }}
         path: ../../im/dist
 
   publish-python-packages-to-pypi:

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "v5.1.0"
+            itk-git-tag: "v5.1.1"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "v5.1.0"
+            itk-git-tag: "v5.1.1"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "v5.1.0"
+            itk-git-tag: "v5.1.1"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -100,6 +100,9 @@ jobs:
         set(dashboard_no_clean 1)
         set(ENV{CC} ${{ matrix.c-compiler }})
         set(ENV{CXX} ${{ matrix.cxx-compiler }})
+        if(WIN32)
+          set(ENV{PATH} "\${CTEST_DASHBOARD_ROOT}/ITK-build/bin;\$ENV{PATH}")
+        endif()
         set(dashboard_cache "
         ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
         BUILD_TESTING:BOOL=ON
@@ -128,9 +131,9 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [35, 36, 37, 38]
+        python-version: [36, 37, 38, 39]
         include:
-          - itk-python-git-tag: "v5.1.0.post3"
+          - itk-python-git-tag: "v5.1.1.post1"
 
     steps:
     - uses: actions/checkout@v2
@@ -166,7 +169,7 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.1.0.post3"
+          - itk-python-git-tag: "v5.1.1.post1"
 
     steps:
     - uses: actions/checkout@v2
@@ -193,9 +196,9 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version-minor: [5, 6, 7, 8]
+        python-version-minor: [6, 7, 8, 9]
         include:
-          - itk-python-git-tag: "v5.1.0.post3"
+          - itk-python-git-tag: "v5.1.1.post1"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -1,0 +1,244 @@
+name: Build, test, package
+
+on: [push,pull_request]
+
+jobs:
+  build-test-cxx:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 3
+      matrix:
+        os: [ubuntu-18.04, windows-2019, macos-10.15]
+        include:
+          - os: ubuntu-18.04
+            c-compiler: "gcc"
+            cxx-compiler: "g++"
+            itk-git-tag: "v5.1.0"
+            cmake-build-type: "MinSizeRel"
+          - os: windows-2019
+            c-compiler: "cl.exe"
+            cxx-compiler: "cl.exe"
+            itk-git-tag: "v5.1.0"
+            cmake-build-type: "Release"
+          - os: macos-10.15
+            c-compiler: "clang"
+            cxx-compiler: "clang++"
+            itk-git-tag: "v5.1.0"
+            cmake-build-type: "MinSizeRel"
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ninja
+
+    - name: Download ITK
+      run: |
+        cd ..
+        git clone https://github.com/InsightSoftwareConsortium/ITK.git
+        cd ITK
+        git checkout ${{ matrix.itk-git-tag }}
+
+    - name: Build ITK
+      if: matrix.os != 'windows-2019'
+      run: |
+        cd ..
+        mkdir ITK-build
+        cd ITK-build
+        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
+        ninja
+
+    - name: Build ITK
+      if: matrix.os == 'windows-2019'
+      run: |
+        cd ..
+        mkdir ITK-build
+        cd ITK-build
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
+        ninja
+      shell: cmd
+
+    - name: Fetch CTest driver script
+      run: |
+        curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/dashboard/itk_common.cmake -O
+
+    - name: Configure CTest script
+      shell: bash
+      run: |
+        operating_system="${{ matrix.os }}"
+        cat > dashboard.cmake << EOF
+        set(CTEST_SITE "GitHubActions")
+        file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/.." CTEST_DASHBOARD_ROOT)
+        file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/" CTEST_SOURCE_DIRECTORY)
+        file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/../build" CTEST_BINARY_DIRECTORY)
+        set(dashboard_source_name "${GITHUB_REPOSITORY}")
+        if(ENV{GITHUB_REF} MATCHES "master")
+          set(branch "-master")
+          set(dashboard_model "Continuous")
+        else()
+          set(branch "-${GITHUB_REF}")
+          set(dashboard_model "Experimental")
+        endif()
+        set(CTEST_BUILD_NAME "${GITHUB_REPOSITORY}-${operating_system}-\${branch}")
+        set(CTEST_UPDATE_VERSION_ONLY 1)
+        set(CTEST_TEST_ARGS \${CTEST_TEST_ARGS} PARALLEL_LEVEL \${PARALLEL_LEVEL})
+        set(CTEST_BUILD_CONFIGURATION "Release")
+        set(CTEST_CMAKE_GENERATOR "Ninja")
+        set(CTEST_CUSTOM_WARNING_EXCEPTION
+          \${CTEST_CUSTOM_WARNING_EXCEPTION}
+          # macOS Azure VM Warning
+          "ld: warning: text-based stub file"
+          )
+        set(dashboard_no_clean 1)
+        set(ENV{CC} ${{ matrix.c-compiler }})
+        set(ENV{CXX} ${{ matrix.cxx-compiler }})
+        set(dashboard_cache "
+        ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
+        BUILD_TESTING:BOOL=ON
+        ")
+        string(TIMESTAMP build_date "%Y-%m-%d")
+        message("CDash Build Identifier: \${build_date} \${CTEST_BUILD_NAME}")
+        message("CTEST_SITE = \${CTEST_SITE}")
+        include(\${CTEST_SCRIPT_DIRECTORY}/itk_common.cmake)
+        EOF
+        cat dashboard.cmake
+
+    - name: Build and test
+      if: matrix.os != 'windows-2019'
+      run: |
+        ctest -j 2 -V -S dashboard.cmake
+
+    - name: Build and test
+      if: matrix.os == 'windows-2019'
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        ctest -j 2 -V -S dashboard.cmake
+      shell: cmd
+
+  build-test-python:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 3
+      matrix:
+        os: [ubuntu-18.04, windows-2019, macos-10.15]
+        include:
+          - os: ubuntu-18.04
+            c-compiler: "gcc"
+            cxx-compiler: "g++"
+            itk-git-tag: "v5.1.0"
+            cmake-build-type: "MinSizeRel"
+          - os: windows-2019
+            c-compiler: "cl.exe"
+            cxx-compiler: "cl.exe"
+            itk-git-tag: "v5.1.0"
+            cmake-build-type: "Release"
+          - os: macos-10.15
+            c-compiler: "clang"
+            cxx-compiler: "clang++"
+            itk-git-tag: "v5.1.0"
+            cmake-build-type: "MinSizeRel"
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ninja
+
+      - name: Download ITK
+        run: |
+          cd ..
+          git clone https://github.com/InsightSoftwareConsortium/ITK.git
+          cd ITK
+          git checkout ${{ matrix.itk-git-tag }}
+
+      - name: Build ITK
+        if: matrix.os != 'windows-2019'
+        run: |
+          cd ..
+          mkdir ITK-build
+          cd ITK-build
+          cmake -DITK_WRAP_PYTHON:BOOL=ON -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
+          ninja
+
+      - name: Build ITK
+        if: matrix.os == 'windows-2019'
+        run: |
+          cd ..
+          mkdir ITK-build
+          cd ITK-build
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          cmake -DITK_WRAP_PYTHON:BOOL=ON -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
+          ninja
+        shell: cmd
+
+      - name: Fetch CTest driver script
+        run: |
+          curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/dashboard/itk_common.cmake -O
+
+      - name: Configure CTest script
+        shell: bash
+        run: |
+          operating_system="${{ matrix.os }}"
+          cat > dashboard.cmake << EOF
+          set(CTEST_SITE "GitHubActions")
+          file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/.." CTEST_DASHBOARD_ROOT)
+          file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/" CTEST_SOURCE_DIRECTORY)
+          file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/../build" CTEST_BINARY_DIRECTORY)
+          set(dashboard_source_name "${GITHUB_REPOSITORY}")
+          if(ENV{GITHUB_REF} MATCHES "master")
+            set(branch "-master")
+            set(dashboard_model "Continuous")
+          else()
+            set(branch "-${GITHUB_REF}")
+            set(dashboard_model "Experimental")
+          endif()
+          set(CTEST_BUILD_NAME "${GITHUB_REPOSITORY}-${operating_system}-\${branch}")
+          set(CTEST_UPDATE_VERSION_ONLY 1)
+          set(CTEST_TEST_ARGS \${CTEST_TEST_ARGS} PARALLEL_LEVEL \${PARALLEL_LEVEL})
+          set(CTEST_BUILD_CONFIGURATION "Release")
+          set(CTEST_CMAKE_GENERATOR "Ninja")
+          set(CTEST_CUSTOM_WARNING_EXCEPTION
+            \${CTEST_CUSTOM_WARNING_EXCEPTION}
+            # macOS Azure VM Warning
+            "ld: warning: text-based stub file"
+            )
+          set(dashboard_no_clean 1)
+          set(ENV{CC} ${{ matrix.c-compiler }})
+          set(ENV{CXX} ${{ matrix.cxx-compiler }})
+          set(dashboard_cache "
+          ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
+          BUILD_TESTING:BOOL=ON
+          ")
+          string(TIMESTAMP build_date "%Y-%m-%d")
+          message("CDash Build Identifier: \${build_date} \${CTEST_BUILD_NAME}")
+          message("CTEST_SITE = \${CTEST_SITE}")
+          include(\${CTEST_SCRIPT_DIRECTORY}/itk_common.cmake)
+          EOF
+          cat dashboard.cmake
+
+      - name: Build and test
+        if: matrix.os != 'windows-2019'
+        run: |
+          ctest -j 2 -V -S dashboard.cmake
+
+      - name: Build and test
+        if: matrix.os == 'windows-2019'
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          ctest -j 2 -V -S dashboard.cmake
+        shell: cmd

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -114,131 +114,152 @@ jobs:
     - name: Build and test
       if: matrix.os != 'windows-2019'
       run: |
-        ctest -j 2 -V -S dashboard.cmake
+        ctest --output-on-failure -j 2 -V -S dashboard.cmake
 
     - name: Build and test
       if: matrix.os == 'windows-2019'
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        ctest -j 2 -V -S dashboard.cmake
+        ctest --output-on-failure -j 2 -V -S dashboard.cmake
       shell: cmd
 
-  build-test-python:
-    runs-on: ${{ matrix.os }}
+  build-linux-python-packages:
+    runs-on: ubuntu-18.04
     strategy:
-      max-parallel: 3
+      max-parallel: 2
       matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
+        python-version: [35, 36, 37, 38]
         include:
-          - os: ubuntu-18.04
-            c-compiler: "gcc"
-            cxx-compiler: "g++"
-            itk-git-tag: "v5.1.0"
-            cmake-build-type: "MinSizeRel"
-          - os: windows-2019
-            c-compiler: "cl.exe"
-            cxx-compiler: "cl.exe"
-            itk-git-tag: "v5.1.0"
-            cmake-build-type: "Release"
-          - os: macos-10.15
-            c-compiler: "clang"
-            cxx-compiler: "clang++"
-            itk-git-tag: "v5.1.0"
-            cmake-build-type: "MinSizeRel"
+          - itk-python-git-tag: "v5.1.0.post3"
 
     steps:
-      - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
+    - name: 'Free up disk space'
+      run: |
+        # Workaround for https://github.com/actions/virtual-environments/issues/709
+        df -h
+        sudo apt-get clean
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        df -h
 
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install ninja
+    - name: 'Fetch build script'
+      run: |
+        curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh -O
+        chmod u+x dockcross-manylinux-download-cache-and-build-module-wheels.sh
 
-      - name: Download ITK
-        run: |
-          cd ..
-          git clone https://github.com/InsightSoftwareConsortium/ITK.git
-          cd ITK
-          git checkout ${{ matrix.itk-git-tag }}
+    - name: 'Build 🐍 Python 📦 package'
+      run: |
+        export ITK_PACKAGE_VERSION=${{ matrix.itk-python-git-tag }}
+        ./dockcross-manylinux-download-cache-and-build-module-wheels.sh cp${{ matrix.python-version }}
 
-      - name: Build ITK
-        if: matrix.os != 'windows-2019'
-        run: |
-          cd ..
-          mkdir ITK-build
-          cd ITK-build
-          cmake -DITK_WRAP_PYTHON:BOOL=ON -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
-          ninja
+    - name: Publish Python package as GitHub Artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: LinuxWheel${{ matrix.python-version }}
+        path: dist
 
-      - name: Build ITK
-        if: matrix.os == 'windows-2019'
-        run: |
-          cd ..
-          mkdir ITK-build
-          cd ITK-build
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          cmake -DITK_WRAP_PYTHON:BOOL=ON -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
-          ninja
-        shell: cmd
+  build-macos-python-packages:
+    runs-on: macos-10.15
+    strategy:
+      max-parallel: 2
+      matrix:
+        include:
+          - itk-python-git-tag: "v5.1.0.post3"
 
-      - name: Fetch CTest driver script
-        run: |
-          curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/dashboard/itk_common.cmake -O
+    steps:
+    - uses: actions/checkout@v2
 
-      - name: Configure CTest script
-        shell: bash
-        run: |
-          operating_system="${{ matrix.os }}"
-          cat > dashboard.cmake << EOF
-          set(CTEST_SITE "GitHubActions")
-          file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/.." CTEST_DASHBOARD_ROOT)
-          file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/" CTEST_SOURCE_DIRECTORY)
-          file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/../build" CTEST_BINARY_DIRECTORY)
-          set(dashboard_source_name "${GITHUB_REPOSITORY}")
-          if(ENV{GITHUB_REF} MATCHES "master")
-            set(branch "-master")
-            set(dashboard_model "Continuous")
-          else()
-            set(branch "-${GITHUB_REF}")
-            set(dashboard_model "Experimental")
-          endif()
-          set(CTEST_BUILD_NAME "${GITHUB_REPOSITORY}-${operating_system}-\${branch}")
-          set(CTEST_UPDATE_VERSION_ONLY 1)
-          set(CTEST_TEST_ARGS \${CTEST_TEST_ARGS} PARALLEL_LEVEL \${PARALLEL_LEVEL})
-          set(CTEST_BUILD_CONFIGURATION "Release")
-          set(CTEST_CMAKE_GENERATOR "Ninja")
-          set(CTEST_CUSTOM_WARNING_EXCEPTION
-            \${CTEST_CUSTOM_WARNING_EXCEPTION}
-            # macOS Azure VM Warning
-            "ld: warning: text-based stub file"
-            )
-          set(dashboard_no_clean 1)
-          set(ENV{CC} ${{ matrix.c-compiler }})
-          set(ENV{CXX} ${{ matrix.cxx-compiler }})
-          set(dashboard_cache "
-          ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
-          BUILD_TESTING:BOOL=ON
-          ")
-          string(TIMESTAMP build_date "%Y-%m-%d")
-          message("CDash Build Identifier: \${build_date} \${CTEST_BUILD_NAME}")
-          message("CTEST_SITE = \${CTEST_SITE}")
-          include(\${CTEST_SCRIPT_DIRECTORY}/itk_common.cmake)
-          EOF
-          cat dashboard.cmake
+    - name: 'Fetch build script'
+      run: |
+        curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/macpython-download-cache-and-build-module-wheels.sh -O
+        chmod u+x macpython-download-cache-and-build-module-wheels.sh
 
-      - name: Build and test
-        if: matrix.os != 'windows-2019'
-        run: |
-          ctest -j 2 -V -S dashboard.cmake
+    - name: 'Build 🐍 Python 📦 package'
+      run: |
+        export ITK_PACKAGE_VERSION=${{ matrix.itk-python-git-tag }}
+        export MACOSX_DEPLOYMENT_TARGET=10.9
+        ./macpython-download-cache-and-build-module-wheels.sh
 
-      - name: Build and test
-        if: matrix.os == 'windows-2019'
-        run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          ctest -j 2 -V -S dashboard.cmake
-        shell: cmd
+    - name: Publish Python package as GitHub Artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: MacOSWheels
+        path: dist
+
+  build-windows-python-packages:
+    runs-on: windows-2019
+    strategy:
+      max-parallel: 2
+      matrix:
+        python-version-minor: [5, 6, 7, 8]
+        include:
+          - itk-python-git-tag: "v5.1.0.post3"
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: "im"
+
+    - name: 'Install Python'
+      run: |
+        $pythonArch = "64"
+        $pythonVersion = "3.${{ matrix.python-version-minor }}"
+        iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/scikit-build/scikit-ci-addons/master/windows/install-python.ps1'))
+
+    - name: 'Fetch build dependencies'
+      shell: bash
+      run: |
+        mv im ../../
+        cd ../../
+        curl -L "https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/download/${{ matrix.itk-python-git-tag }}/ITKPythonBuilds-windows.zip" -o "ITKPythonBuilds-windows.zip"
+        7z x ITKPythonBuilds-windows.zip -o/c/P -aoa -r
+        curl -L "https://data.kitware.com/api/v1/file/5c0ad59d8d777f2179dd3e9c/download" -o "doxygen-1.8.11.windows.bin.zip"
+        7z x doxygen-1.8.11.windows.bin.zip -o/c/P/doxygen -aoa -r
+        curl -L "https://data.kitware.com/api/v1/file/5bbf87ba8d777f06b91f27d6/download/grep-win.zip" -o "grep-win.zip"
+        7z x grep-win.zip -o/c/P/grep -aoa -r
+
+    - name: 'Build 🐍 Python 📦 package'
+      shell: cmd
+      run: |
+        cd ../../im
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        set PATH="C:\P\grep;%PATH%"
+        set CC=cl.exe
+        set CXX=cl.exe
+        C:\Python3${{ matrix.python-version-minor }}-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py --py-envs "3${{ matrix.python-version-minor }}-x64" --no-cleanup
+
+    - name: Publish Python package as GitHub Artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: WindowWheel3.${{ matrix.python-version-minor }}
+        path: ../../im/dist
+
+  publish-python-packages-to-pypi:
+    needs:
+      - build-linux-python-packages
+      - build-macos-python-packages
+      - build-windows-python-packages
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Download Python Packages
+      uses: actions/download-artifact@v2
+
+    - name: Prepare packages for upload
+      run: |
+        ls -R
+        for d in */; do
+          mv ${d}/*.whl .
+        done
+        mkdir dist
+        mv *.whl dist/
+        ls dist
+
+    - name: Publish 🐍 Python 📦 package to PyPI
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -1,0 +1,13 @@
+name: clang-format linter
+
+on: [push,pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,7 @@
+set(CTEST_PROJECT_NAME "ITK")
+set(CTEST_NIGHTLY_START_TIME "1:00:00 UTC")
+
+set(CTEST_DROP_METHOD "https")
+set(CTEST_DROP_SITE "open.cdash.org")
+set(CTEST_DROP_LOCATION "/submit.php?project=Insight")
+set(CTEST_DROP_SITE_CDASH TRUE)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 itkMGHImageIO
 =============
 
+![Build, test, package status](https://github.com/Slicer/itkMGHImageIO/workflows/Build,%20test,%20package/badge.svg)
+[![PyPI Version](https://img.shields.io/pypi/v/itk-iomgh.svg)](https://pypi.python.org/pypi/itk-iomgh)
+
 A copy of the Slicer itkMGHImageIO mechanism for ITK.
 
 The intent of this repository is to extract the itkMGHImageIO from it's embedded Slicer only implementation and make it accessible to any ITK compliant program.
-
-This will be accomplished using the ITKv4 "Remote Module" mechanism as defined at.
-
-http://www.itk.org/Wiki/ITK/Policy_and_Procedures_for_Adding_Remote_Modules
-
-

--- a/include/itkMGHImageIOFactory.h
+++ b/include/itkMGHImageIOFactory.h
@@ -33,7 +33,7 @@ namespace itk
 class MGHIO_EXPORT MGHImageIOFactory : public ObjectFactoryBase
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MGHImageIOFactory);
+  ITK_DISALLOW_COPY_AND_MOVE(MGHImageIOFactory);
 
   /** Standard class type alias */
   using Self = MGHImageIOFactory;

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except ImportError:
 
 setup(
     name='itk-iomgh',
-    version='1.0.0',
+    version='1.1.0',
     author='Insight Software Consortium',
     author_email='community@itk.org',
     packages=['itk'],
@@ -47,6 +47,6 @@ setup(
     keywords='ITK InsightToolkit MGH Slicer',
     url=r'https://itk.org/',
     install_requires=[
-        r'itk>=5.1.0.post3'
+        r'itk>=5.1.1'
     ]
     )

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,6 @@ setup(
     keywords='ITK InsightToolkit MGH Slicer',
     url=r'https://itk.org/',
     install_requires=[
-        r'itk>=5.1.1'
+        r'itk>=5.2rc1'
     ]
     )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,52 @@
+from os import sys
+
+try:
+    from skbuild import setup
+except ImportError:
+    print('scikit-build is required to build from source.', file=sys.stderr)
+    print('Please run:', file=sys.stderr)
+    print('', file=sys.stderr)
+    print('  python -m pip install scikit-build')
+    sys.exit(1)
+
+setup(
+    name='itk-iomgh',
+    version='1.0.0',
+    author='Insight Software Consortium',
+    author_email='community@itk.org',
+    packages=['itk'],
+    package_dir={'itk': 'itk'},
+    download_url=r'https://github.com/Slicer/itkMGHImageIO.git',
+    description=r'An ITK module to support input and output of the MGH file format.',
+    long_description='ITK is an open-source, cross-platform library that '
+                     'provides developers with an extensive suite of software '
+                     'tools for image analysis. Developed through extreme '
+                     'programming methodologies, ITK employs leading-edge '
+                     'algorithms for registering and segmenting '
+                     'multidimensional scientific images.',
+    classifiers=[
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python",
+        "Programming Language :: C++",
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Education",
+        "Intended Audience :: Healthcare Industry",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Medical Science Apps.",
+        "Topic :: Scientific/Engineering :: Information Analysis",
+        "Topic :: Software Development :: Libraries",
+        "Operating System :: Android",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: POSIX",
+        "Operating System :: Unix",
+        "Operating System :: MacOS"
+        ],
+    license='Apache',
+    keywords='ITK InsightToolkit MGH Slicer',
+    url=r'https://itk.org/',
+    install_requires=[
+        r'itk>=5.1.0.post3'
+    ]
+    )

--- a/src/itkMGHImageIO.cxx
+++ b/src/itkMGHImageIO.cxx
@@ -771,7 +771,7 @@ MGHImageIO ::GetOrientation(itk::Matrix<double> directions)
     const double sag = directions(0, cAxes); // LR axis
     const double cor = directions(1, cAxes); // PA axis
     const double ax = directions(2, cAxes);  // IS axis
-    if (fabs(sag) > fabs(cor) && fabs(sag) > fabs(ax))
+    if (itk::Math::abs(sag) > itk::Math::abs(cor) && itk::Math::abs(sag) > itk::Math::abs(ax))
     {
       if (sag > 0)
       {
@@ -783,7 +783,7 @@ MGHImageIO ::GetOrientation(itk::Matrix<double> directions)
       }
       continue;
     }
-    if (fabs(cor) > fabs(ax))
+    if (itk::Math::abs(cor) > itk::Math::abs(ax))
     {
       if (cor > 0)
       {


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

