### PR TITLE
BUG: Use the superclass name in itkTypeMacro

### DIFF
--- a/include/itkMGHImageIO.h
+++ b/include/itkMGHImageIO.h
@@ -50,7 +50,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MGHImageIO, Superclass);
+  itkTypeMacro(MGHImageIO, ImageIOBase);
 
   /*-------- This part of the interfaces deals with reading data. ----- */
 


### PR DESCRIPTION
Use the superclass name instead of the `Superclass` alias in `itkTypeMacro`