### PR TITLE
COMP: Use modern macro for name of class

### DIFF
--- a/include/itkMGHImageIO.h
+++ b/include/itkMGHImageIO.h
@@ -50,7 +50,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MGHImageIO, ImageIOBase);
+  itkOverrideGetNameOfClassMacro(MGHImageIO);
 
   /*-------- This part of the interfaces deals with reading data. ----- */
 

--- a/include/itkMGHImageIOFactory.h
+++ b/include/itkMGHImageIOFactory.h
@@ -52,7 +52,7 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MGHImageIOFactory, ObjectFactoryBase);
+  itkOverrideGetNameOfClassMacro(MGHImageIOFactory);
 
   /** Register one factory of this type */
   static void


### PR DESCRIPTION
When preparing for the future with ITK by setting
 ITK_FUTURE_LEGACY_REMOVE:BOOL=ON
 ITK_LEGACY_REMOVEBOOL=ON

The future preferred macro should be used
│ -  itkTypeMacro(MGHImageIOFactory, ObjectFactoryBase); │ +  itkOverrideGetNameOfClassMacro(MGHImageIOFactory);