### PR TITLE
ENH: Modernize CMake to use itk_module_add_library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,4 @@ itkMGHImageIOFactory.cxx
 itkMGHImageIO.cxx
 )
 
-add_library(MGHIO ${ITK_LIBRARY_BUILD_TYPE} ${MGHIO_SRC})
-target_link_libraries(MGHIO ${ITKIOImageBase_LIBRARIES} ${ITKZLIB_LIBRARIES})
-itk_module_target(MGHIO)
+itk_module_add_library(MGHIO ${MGHIO_SRC})


### PR DESCRIPTION
Replace add_library with itk_module_add_library macro for better integration with ITK module system. This provides automatic dependency linking, include directory setup, and consistent target naming.